### PR TITLE
Support a new flag to present a regex filtered view of metrics

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -34,9 +34,13 @@ func writeBody(w io.Writer, body string) {
 	}
 }
 
-func metricsHandler(ipcPath string) http.HandlerFunc {
+func metricsHandler(ipcPath string, defaultFilter string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		filters := r.URL.Query()["collect[]"]
+		if defaultFilter != "" {
+			filters = append(filters, defaultFilter)
+		}
+
 		registry := newRegistry(ipcPath, filters)
 		gatherers := prometheus.Gatherers{
 			registry,

--- a/main.go
+++ b/main.go
@@ -9,13 +9,15 @@ import (
 )
 
 const (
-	metricsPath = "/metrics"
+	metricsPath         = "/metrics"
+	filteredMetricsPath = "/filteredmetrics"
 )
 
 var (
 	ipcPathFlag = flag.String("ipc", "", "path to ipc file")
 	hostFlag    = flag.String("host", "", "http server host")
 	portFlag    = flag.Int("port", 9200, "http server port")
+	filterFlag  = flag.String("filter", "", "regex filters")
 )
 
 func usage() {
@@ -44,9 +46,13 @@ func parseFlags() {
 func main() {
 	parseFlags()
 
-	http.HandleFunc(metricsPath, metricsHandler(*ipcPathFlag))
+	http.HandleFunc(metricsPath, metricsHandler(*ipcPathFlag, ""))
 	http.HandleFunc("/health", healthHandler)
 	http.HandleFunc("/", rootHandler)
+
+	if *filterFlag != "" {
+		http.HandleFunc(filteredMetricsPath, metricsHandler(*ipcPathFlag, *filterFlag))
+	}
 
 	listenAddress := fmt.Sprintf("%s:%d", *hostFlag, *portFlag)
 


### PR DESCRIPTION
Support a new flag to present a regex filtered view of metrics so we can expose all metrics to the /metrics endpoint and export only a subset to prom exporter and SD. 

There are two types of existing filtering that aren't quite right --
* regex in a URL param to geth-exporter - but would require a code change in prom-to-sd to allow params to get passed rather than just code component, and we don't really want to change this codebase if we can help it
* exact match whitelisting via param in prom-to-sd, but we really want all metrics, just not all 'measures' of them.  

Tested locally. 