### PR TITLE
Make public docker image

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,5 @@
 steps:
  - name: 'gcr.io/cloud-builders/docker'
-   args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/geth-exporter:$COMMIT_SHA', '.' ]
+   args: [ 'build', '-t', 'us.gcr.io/$PROJECT_ID/geth-exporter:$COMMIT_SHA', '.' ]
 images:
- - 'gcr.io/$PROJECT_ID/geth-exporter:$COMMIT_SHA'
+ - 'us.gcr.io/$PROJECT_ID/geth-exporter:$COMMIT_SHA'


### PR DESCRIPTION
Make docker image public in Google Container Registry

Change the repo of the docker image to `us.gcr.io/...` so the cloudbuild image can be downloaded by anyone.
This image is used by the public terraform modules for deploying Validator and Proxy.

Important changes:
- [x]The docker image would be public.

